### PR TITLE
feat: better private properties handling

### DIFF
--- a/src/AutoMapperBundle.php
+++ b/src/AutoMapperBundle.php
@@ -4,6 +4,7 @@ namespace AutoMapper\Bundle;
 
 use AutoMapper\Bundle\DependencyInjection\AutoMapperExtension;
 use AutoMapper\Bundle\DependencyInjection\Compiler\MapperConfigurationPass;
+use AutoMapper\Bundle\DependencyInjection\Compiler\PropertyInfoPass;
 use AutoMapper\Bundle\DependencyInjection\Compiler\TransformerFactoryPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
@@ -16,6 +17,7 @@ class AutoMapperBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new MapperConfigurationPass());
+        $container->addCompilerPass(new PropertyInfoPass());
         $container->addCompilerPass(new TransformerFactoryPass());
     }
 

--- a/src/DependencyInjection/AutoMapperExtension.php
+++ b/src/DependencyInjection/AutoMapperExtension.php
@@ -40,7 +40,11 @@ class AutoMapperExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
 
-        $container->getDefinition(MapperGeneratorMetadataFactory::class)->replaceArgument(5, $config['date_time_format']);
+        $container->getDefinition(MapperGeneratorMetadataFactory::class)
+            ->replaceArgument(5, $config['date_time_format'])
+            ->replaceArgument(6, $config['map_private_properties'])
+        ;
+
         $container->getDefinition(FileLoader::class)->replaceArgument(2, $config['hot_reload']);
         $container->registerForAutoconfiguration(TransformerFactoryInterface::class)->addTag('automapper.transformer_factory');
 

--- a/src/DependencyInjection/Compiler/PropertyInfoPass.php
+++ b/src/DependencyInjection/Compiler/PropertyInfoPass.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace AutoMapper\Bundle\DependencyInjection\Compiler;
+
+use AutoMapper\Extractor\MapToContextPropertyInfoExtractorDecorator;
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoCacheExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+
+class PropertyInfoPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->has('property_info')) {
+            return;
+        }
+
+        $propertyInfoDefinition = $container->findDefinition('property_info');
+
+        $container->setDefinition(
+            'automapper.property_info.reflection_extractor.inner',
+            new Definition(
+                ReflectionExtractor::class,
+                [
+                    '$accessFlags' => ReflectionExtractor::ALLOW_PUBLIC | ReflectionExtractor::ALLOW_PROTECTED | ReflectionExtractor::ALLOW_PRIVATE,
+                ]
+            )
+        );
+
+        $container->setDefinition(
+            'automapper.property_info.reflection_extractor',
+            new Definition(
+                MapToContextPropertyInfoExtractorDecorator::class,
+                [
+                    new Reference('automapper.property_info.reflection_extractor.inner'),
+                ]
+            )
+        );
+
+        $container->setDefinition(
+            'automapper.property_info',
+            new Definition(
+                PropertyInfoExtractor::class,
+                [
+                    $this->replaceReflectionExtractor($propertyInfoDefinition->getArgument(0)),
+                    $this->replaceReflectionExtractor($propertyInfoDefinition->getArgument(1)),
+                    $this->replaceReflectionExtractor($propertyInfoDefinition->getArgument(2)),
+                    $this->replaceReflectionExtractor($propertyInfoDefinition->getArgument(3)),
+                    $this->replaceReflectionExtractor($propertyInfoDefinition->getArgument(4)),
+                ]
+            )
+        );
+
+        $container->setDefinition(
+            'automapper.property_info.cache',
+            new Definition(PropertyInfoCacheExtractor::class, [
+                new Reference('.inner'),
+                new Reference('cache.property_info'),
+            ])
+        )->setDecoratedService('automapper.property_info');
+    }
+
+    private function replaceReflectionExtractor(IteratorArgument $extractors): IteratorArgument
+    {
+        $newExtractors = [];
+
+        /** @var Reference $extractor */
+        foreach ($extractors->getValues() as $extractor) {
+            $newExtractors[] = (string) $extractor === 'property_info.reflection_extractor'
+                ? new Reference('automapper.property_info.reflection_extractor')
+                : $extractor;
+        }
+
+        return new IteratorArgument($newExtractors);
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -29,6 +29,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('cache_dir')->defaultValue('%kernel.cache_dir%/automapper')->end()
                 ->scalarNode('date_time_format')->defaultValue(\DateTimeInterface::RFC3339)->end()
                 ->booleanNode('hot_reload')->defaultValue($this->debug)->end()
+                ->booleanNode('map_private_properties')->defaultTrue()->end()
                 ->booleanNode('allow_readonly_target_to_populate')->defaultFalse()->end()
                 ->arrayNode('warmup')
                     ->arrayPrototype()

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -13,24 +13,24 @@
         <service id="AutoMapper\AutoMapperRegistryInterface" alias="AutoMapper\Bundle\AutoMapper" public="true" />
 
         <service id="AutoMapper\Extractor\SourceTargetMappingExtractor">
-            <argument type="service" id="property_info" />
-            <argument type="service" id="AutoMapper\Extractor\MapToContextPropertyInfoExtractorDecorator" />
-            <argument type="service" id="property_info.reflection_extractor" />
+            <argument type="service" id="automapper.property_info" />
+            <argument type="service" id="automapper.property_info.reflection_extractor" />
+            <argument type="service" id="automapper.property_info.reflection_extractor" />
             <argument type="service" id="AutoMapper\Transformer\TransformerFactoryInterface" />
         </service>
 
         <service id="AutoMapper\Extractor\FromTargetMappingExtractor">
-            <argument type="service" id="property_info" />
-            <argument type="service" id="property_info.reflection_extractor" />
-            <argument type="service" id="property_info.reflection_extractor" />
+            <argument type="service" id="automapper.property_info" />
+            <argument type="service" id="automapper.property_info.reflection_extractor" />
+            <argument type="service" id="automapper.property_info.reflection_extractor" />
             <argument type="service" id="AutoMapper\Transformer\TransformerFactoryInterface" />
             <argument type="service" id="serializer.mapping.class_metadata_factory" />
         </service>
 
         <service id="AutoMapper\Extractor\FromSourceMappingExtractor">
-            <argument type="service" id="property_info" />
-            <argument type="service" id="AutoMapper\Extractor\MapToContextPropertyInfoExtractorDecorator" />
-            <argument type="service" id="property_info.reflection_extractor" />
+            <argument type="service" id="automapper.property_info" />
+            <argument type="service" id="automapper.property_info.reflection_extractor" />
+            <argument type="service" id="automapper.property_info.reflection_extractor" />
             <argument type="service" id="AutoMapper\Transformer\TransformerFactoryInterface" />
             <argument type="service" id="serializer.mapping.class_metadata_factory" />
         </service>
@@ -42,6 +42,7 @@
             <argument>Symfony_Mapper_</argument>
             <argument>true</argument>
             <argument></argument> <!-- Date time format -->
+            <argument></argument> <!-- map_private_properties -->
         </service>
         <service id="AutoMapper\MapperGeneratorMetadataFactoryInterface" alias="AutoMapper\MapperGeneratorMetadataFactory" />
 
@@ -118,11 +119,6 @@
         <service id="AutoMapper\Bundle\CacheWarmup\ConfigurationCacheWarmerLoader">
             <argument/> <!-- mappers list from config -->
             <tag name="automapper.cache_warmer_loader" />
-        </service>
-
-        <service id="AutoMapper\Extractor\MapToContextPropertyInfoExtractorDecorator">
-            <argument type="service" id="property_info.reflection_extractor" />
-            <tag name="property_info.access_extractor" priority="-100" />
         </service>
     </services>
 </container>

--- a/tests/Fixtures/ClassWithMapToContextAttribute.php
+++ b/tests/Fixtures/ClassWithMapToContextAttribute.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace AutoMapper\Bundle\Tests\Fixtures;
+
+use AutoMapper\Attribute\MapToContext;
+
+class ClassWithMapToContextAttribute
+{
+    public function __construct(
+        private string $value,
+    ) {
+    }
+
+    public function getValue(
+        #[MapToContext('prefix')] string $prefix,
+        #[MapToContext('suffix')] string $suffix,
+    ): string {
+        return "{$prefix}_{$this->value}_{$suffix}";
+    }
+
+    public function getVirtualProperty(
+        #[MapToContext('prefix')] string $prefix,
+        #[MapToContext('suffix')] string $suffix,
+    ): string {
+        return "{$prefix}_{$this->value}_{$suffix}";
+    }
+
+    public function getPropertyWithDefaultValue(
+        string $someVar = 'foo',
+    ): string {
+        return $someVar;
+    }
+}

--- a/tests/Fixtures/ClassWithPrivateProperty.php
+++ b/tests/Fixtures/ClassWithPrivateProperty.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace AutoMapper\Bundle\Tests\Fixtures;
+
+class ClassWithPrivateProperty
+{
+    public function __construct(private string $foo)
+    {
+    }
+
+    private function getBar(): string
+    {
+        return 'bar';
+    }
+}

--- a/tests/Resources/App/config.yml
+++ b/tests/Resources/App/config.yml
@@ -6,6 +6,7 @@ framework:
 automapper:
     normalizer: true
     name_converter: DummyApp\IdNameConverter
+    map_private_properties: true
     warmup:
       - { source: 'AutoMapper\Bundle\Tests\Fixtures\NestedObject', target: 'array' }
 


### PR DESCRIPTION
some work have been made around `property_info`, in order not to modify the main `property_info` of the app, which would have been very intrusive and could lead to really weird problems in userland, which would even seem not to be related to the autmapper:
- create it's own `property_info` service for automapper
- decorate `property_info.reflection_extractor` with `MapToContextPropertyInfoExtractorDecorator` only in `automapper.property_info`
- configure the `$accessFlags` for `automapper.property_info.reflection_extractor` in order that we can read private properties

then, this PR adds a new `map_private_properties` in order to control if automapper can access to private properties and private getters from source