### PR TITLE
fix tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "jolicode/automapper-bundle",
-    "type": "library",
+    "type": "symfony-bundle",
     "description": "JoliCode AutoMapper Symfony Bundle",
     "keywords": ["bundle", "symfony"],
     "homepage": "https://github.com/jolicode/automapper-bundle",
@@ -17,10 +17,11 @@
     ],
     "require": {
         "php": "^8.2",
-        "jolicode/automapper": "dev-main"
+        "jolicode/automapper": "^8.0"
     },
     "require-dev": {
         "moneyphp/money": "^4.2",
+        "phpdocumentor/reflection-docblock": "^5.3",
         "phpunit/phpunit": "^8.0",
         "symfony/framework-bundle": "^6.0",
         "symfony/uid": "^6.3",

--- a/src/CacheWarmup/CacheWarmer.php
+++ b/src/CacheWarmup/CacheWarmer.php
@@ -42,7 +42,7 @@ final class CacheWarmer implements CacheWarmerInterface
         }
 
         // preloaded files must be in cache directory
-        if (0 !== strpos($this->autoMapperCacheDirectory, $cacheDir)) {
+        if (!str_starts_with($this->autoMapperCacheDirectory, $cacheDir)) {
             return [];
         }
 
@@ -51,13 +51,13 @@ final class CacheWarmer implements CacheWarmerInterface
             return [];
         }
 
-        $mapppers = array_keys(require $registryFile);
+        $mappers = array_keys(require $registryFile);
 
         return array_map(
             function ($mapper) {
                 return sprintf('%s/%s.php', $this->autoMapperCacheDirectory, $mapper);
             },
-            $mapppers
+            $mappers
         );
     }
 }

--- a/tests/Fixtures/Pet.php
+++ b/tests/Fixtures/Pet.php
@@ -4,12 +4,12 @@ namespace AutoMapper\Bundle\Tests\Fixtures;
 
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
 
-/**
- * @DiscriminatorMap(typeProperty="type", mapping={
- *    "cat"="AutoMapper\Bundle\Tests\Fixtures\Cat",
- *    "dog"="AutoMapper\Bundle\Tests\Fixtures\Dog"
- * })
- */
+#[
+    DiscriminatorMap(typeProperty: 'type', mapping: [
+        'cat' => Cat::class,
+        'dog' => Dog::class,
+    ])
+]
 class Pet
 {
     /** @var string */

--- a/tests/Resources/App/Transformer/MoneyToArrayTransformer.php
+++ b/tests/Resources/App/Transformer/MoneyToArrayTransformer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AutoMapper\Bundle\tests\Resources\App\Transformer;
+namespace AutoMapper\Bundle\Tests\Resources\App\Transformer;
 
 use AutoMapper\Extractor\PropertyMapping;
 use AutoMapper\Generator\UniqueVariableScope;

--- a/tests/Resources/App/Transformer/MoneyToMoneyTransformer.php
+++ b/tests/Resources/App/Transformer/MoneyToMoneyTransformer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AutoMapper\Bundle\tests\Resources\App\Transformer;
+namespace AutoMapper\Bundle\Tests\Resources\App\Transformer;
 
 use AutoMapper\Extractor\PropertyMapping;
 use AutoMapper\Generator\UniqueVariableScope;

--- a/tests/Resources/App/Transformer/MoneyTransformerFactory.php
+++ b/tests/Resources/App/Transformer/MoneyTransformerFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AutoMapper\Bundle\tests\Resources\App\Transformer;
+namespace AutoMapper\Bundle\Tests\Resources\App\Transformer;
 
 use AutoMapper\MapperMetadataInterface;
 use AutoMapper\Transformer\AbstractUniqueTypeTransformerFactory;

--- a/tests/Resources/App/config.yml
+++ b/tests/Resources/App/config.yml
@@ -15,4 +15,4 @@ services:
 
   DummyApp\UserMapperConfiguration: ~
   DummyApp\IdNameConverter: ~
-  DummyApp\Transformer\MoneyTransformerFactory: ~
+  AutoMapper\Bundle\Tests\Resources\App\Transformer\MoneyTransformerFactory: ~

--- a/tests/ServiceInstantiationTest.php
+++ b/tests/ServiceInstantiationTest.php
@@ -2,13 +2,13 @@
 
 namespace AutoMapper\Bundle\Tests;
 
+use AutoMapper\AutoMapperInterface;
 use AutoMapper\Bundle\Tests\Fixtures\AddressDTO;
 use AutoMapper\Bundle\Tests\Fixtures\DTOWithEnum;
 use AutoMapper\Bundle\Tests\Fixtures\Order;
 use AutoMapper\Bundle\Tests\Fixtures\SomeEnum;
 use AutoMapper\Bundle\Tests\Fixtures\User;
 use AutoMapper\Bundle\Tests\Fixtures\UserDTO;
-use AutoMapper\AutoMapperInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -32,13 +32,13 @@ class ServiceInstantiationTest extends WebTestCase
     {
         static::bootKernel();
 
-        self::assertFileExists(__DIR__ . '/Resources/var/cache/test/automapper/Symfony_Mapper_Jane_Bundle_AutoMapperBundle_Tests_Fixtures_NestedObject_array.php');
-        self::assertFileExists(__DIR__ . '/Resources/var/cache/test/automapper/Symfony_Mapper_Jane_Bundle_AutoMapperBundle_Tests_Fixtures_User_array.php');
-        self::assertFileExists(__DIR__ . '/Resources/var/cache/test/automapper/Symfony_Mapper_Jane_Bundle_AutoMapperBundle_Tests_Fixtures_AddressDTO_array.php');
+        self::assertFileExists(__DIR__ . '/Resources/var/cache/test/automapper/Symfony_Mapper_AutoMapper_Bundle_Tests_Fixtures_NestedObject_array.php');
+        self::assertFileExists(__DIR__ . '/Resources/var/cache/test/automapper/Symfony_Mapper_AutoMapper_Bundle_Tests_Fixtures_User_array.php');
+        self::assertFileExists(__DIR__ . '/Resources/var/cache/test/automapper/Symfony_Mapper_AutoMapper_Bundle_Tests_Fixtures_AddressDTO_array.php');
 
-        self::assertInstanceOf(\Symfony_Mapper_Jane_Bundle_AutoMapperBundle_Tests_Fixtures_NestedObject_array::class, new \Symfony_Mapper_Jane_Bundle_AutoMapperBundle_Tests_Fixtures_NestedObject_array());
-        self::assertInstanceOf(\Symfony_Mapper_Jane_Bundle_AutoMapperBundle_Tests_Fixtures_User_array::class, new \Symfony_Mapper_Jane_Bundle_AutoMapperBundle_Tests_Fixtures_User_array());
-        self::assertInstanceOf(\Symfony_Mapper_Jane_Bundle_AutoMapperBundle_Tests_Fixtures_AddressDTO_array::class, new \Symfony_Mapper_Jane_Bundle_AutoMapperBundle_Tests_Fixtures_AddressDTO_array());
+        self::assertInstanceOf(\Symfony_Mapper_AutoMapper_Bundle_Tests_Fixtures_NestedObject_array::class, new \Symfony_Mapper_AutoMapper_Bundle_Tests_Fixtures_NestedObject_array());
+        self::assertInstanceOf(\Symfony_Mapper_AutoMapper_Bundle_Tests_Fixtures_User_array::class, new \Symfony_Mapper_AutoMapper_Bundle_Tests_Fixtures_User_array());
+        self::assertInstanceOf(\Symfony_Mapper_AutoMapper_Bundle_Tests_Fixtures_AddressDTO_array::class, new \Symfony_Mapper_AutoMapper_Bundle_Tests_Fixtures_AddressDTO_array());
     }
 
     public function testAutoMapper()
@@ -47,6 +47,7 @@ class ServiceInstantiationTest extends WebTestCase
         $container = static::$kernel->getContainer();
         $this->assertTrue($container->has(AutoMapperInterface::class));
         $autoMapper = $container->get(AutoMapperInterface::class);
+
         $this->assertInstanceOf(AutoMapperInterface::class, $autoMapper);
 
         $address = new AddressDTO();


### PR DESCRIPTION
few minor problems fixed, in particular, required as a dev depenency `phpdocumentor/reflection-docblock` in order to have the right extractors available in property info component.

I'm wondering if we shouldn't make this a hard requirement in the automapper?