### PR TITLE
Change PropertyInfoPass to use the same set of property extractors as the main package

### DIFF
--- a/src/DependencyInjection/Compiler/PropertyInfoPass.php
+++ b/src/DependencyInjection/Compiler/PropertyInfoPass.php
@@ -20,8 +20,6 @@ class PropertyInfoPass implements CompilerPassInterface
             return;
         }
 
-        $propertyInfoDefinition = $container->findDefinition('property_info');
-
         $container->setDefinition(
             'automapper.property_info.reflection_extractor.inner',
             new Definition(
@@ -47,11 +45,19 @@ class PropertyInfoPass implements CompilerPassInterface
             new Definition(
                 PropertyInfoExtractor::class,
                 [
-                    $this->replaceReflectionExtractor($propertyInfoDefinition->getArgument(0)),
-                    $this->replaceReflectionExtractor($propertyInfoDefinition->getArgument(1)),
-                    $this->replaceReflectionExtractor($propertyInfoDefinition->getArgument(2)),
-                    $this->replaceReflectionExtractor($propertyInfoDefinition->getArgument(3)),
-                    $this->replaceReflectionExtractor($propertyInfoDefinition->getArgument(4)),
+                    new IteratorArgument([
+                        new Reference('property_info.reflection_extractor'),
+                    ]),
+                    new IteratorArgument([
+                        new Reference('property_info.php_doc_extractor'),
+                        new Reference('automapper.property_info.reflection_extractor'),
+                    ]),
+                    new IteratorArgument([
+                        new Reference('property_info.reflection_extractor'),
+                    ]),
+                    new IteratorArgument([
+                        new Reference('automapper.property_info.reflection_extractor'),
+                    ]),
                 ]
             )
         );
@@ -63,19 +69,5 @@ class PropertyInfoPass implements CompilerPassInterface
                 new Reference('cache.property_info'),
             ])
         )->setDecoratedService('automapper.property_info');
-    }
-
-    private function replaceReflectionExtractor(IteratorArgument $extractors): IteratorArgument
-    {
-        $newExtractors = [];
-
-        /** @var Reference $extractor */
-        foreach ($extractors->getValues() as $extractor) {
-            $newExtractors[] = (string) $extractor === 'property_info.reflection_extractor'
-                ? new Reference('automapper.property_info.reflection_extractor')
-                : $extractor;
-        }
-
-        return new IteratorArgument($newExtractors);
     }
 }

--- a/src/DependencyInjection/Compiler/PropertyInfoPass.php
+++ b/src/DependencyInjection/Compiler/PropertyInfoPass.php
@@ -53,7 +53,7 @@ class PropertyInfoPass implements CompilerPassInterface
                         new Reference('automapper.property_info.reflection_extractor'),
                     ]),
                     new IteratorArgument([
-                        new Reference('property_info.reflection_extractor'),
+                        new Reference('automapper.property_info.reflection_extractor'),
                     ]),
                     new IteratorArgument([
                         new Reference('automapper.property_info.reflection_extractor'),

--- a/src/DependencyInjection/Compiler/PropertyInfoPass.php
+++ b/src/DependencyInjection/Compiler/PropertyInfoPass.php
@@ -46,7 +46,7 @@ class PropertyInfoPass implements CompilerPassInterface
                 PropertyInfoExtractor::class,
                 [
                     new IteratorArgument([
-                        new Reference('property_info.reflection_extractor'),
+                        new Reference('automapper.property_info.reflection_extractor'),
                     ]),
                     new IteratorArgument([
                         new Reference('property_info.php_doc_extractor'),
@@ -54,6 +54,9 @@ class PropertyInfoPass implements CompilerPassInterface
                     ]),
                     new IteratorArgument([
                         new Reference('property_info.reflection_extractor'),
+                    ]),
+                    new IteratorArgument([
+                        new Reference('automapper.property_info.reflection_extractor'),
                     ]),
                     new IteratorArgument([
                         new Reference('automapper.property_info.reflection_extractor'),

--- a/src/DependencyInjection/Compiler/PropertyInfoPass.php
+++ b/src/DependencyInjection/Compiler/PropertyInfoPass.php
@@ -49,7 +49,7 @@ class PropertyInfoPass implements CompilerPassInterface
                         new Reference('automapper.property_info.reflection_extractor'),
                     ]),
                     new IteratorArgument([
-                        new Reference('property_info.php_doc_extractor'),
+                        new Reference('property_info.phpstan_extractor'),
                         new Reference('automapper.property_info.reflection_extractor'),
                     ]),
                     new IteratorArgument([


### PR DESCRIPTION
This changes the service `automapper.property_info` to use the same property extractors as the main automapper package.

Symfony places `DoctrineExtractor` as the highest priority property info extractor, but a mapper should not have such a behavior. It can lead to surprising situation involving Doctrine entities, where the mapper appears to work in tests, but not in the real code.